### PR TITLE
Disable plaintext fallback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,12 @@ Configuration
 
    I'd recommend you try the default and fall back to 3DES if necessary.
 
+#. By default, when an intended recipient does not have a valid Identity, they
+   will be emailed in plaintext. This behavior can be changed by setting
+   ``DJEMBE_PLAINTEXT_FALLBACK`` to False. When False, plaintext emails will not be
+   sent. Additionally, if ``fail_silently`` is False, a
+   ``djembe.exceptions.UnencryptableRecipients`` exception will be raised.
+
 #. Use the Django admin to add recipients that should receive encrypted mail.
 
    The simplest case is an Identity with a certificate. Any mail sent to that

--- a/djembe/backends.py
+++ b/djembe/backends.py
@@ -156,18 +156,6 @@ class EncryptingBackendMixin(object):
             message = self.sign(sender_identity, message)
 
         sent = 0
-        if plaintext_recipients:
-            try:
-                self.deliver(
-                    sender_address,
-                    plaintext_recipients,
-                    message.as_string()
-                )
-                sent += 1
-            except:
-                if self.fail_silently is False:
-                    raise
-
         if encrypting_identities:
             try:
                 encrypted_message = self.encrypt(
@@ -180,6 +168,18 @@ class EncryptingBackendMixin(object):
                     sender_address,
                     encrypting_recipients,
                     encrypted_message.as_string()
+                )
+                sent += 1
+            except:
+                if self.fail_silently is False:
+                    raise
+
+        if plaintext_recipients:
+            try:
+                self.deliver(
+                    sender_address,
+                    plaintext_recipients,
+                    message.as_string()
                 )
                 sent += 1
             except:

--- a/djembe/exceptions.py
+++ b/djembe/exceptions.py
@@ -1,0 +1,5 @@
+class UnencryptableRecipients(Exception):
+    def __init__(self, encrypting_identities, encrypting_recipients, plaintext_recipients):
+        self.encrypting_identities = encrypting_identities
+        self.encrypting_recipients = encrypting_recipients
+        self.plaintext_recipients = plaintext_recipients

--- a/djembe/tests/test_basics.py
+++ b/djembe/tests/test_basics.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 from djembe.models import Identity
 from djembe.tests import data
+from djembe.exceptions import UnencryptableRecipients
 
 from M2Crypto import BIO
 from M2Crypto import SMIME
@@ -208,3 +209,25 @@ class EncryptionTest(TestCase):
         )
         sender = backend.get_sender_identity(sender_address)
         self.assertTrue(sender is None)
+
+    def testDisabledPlaintextFallback(self):
+        subject = 'Multiple recipients'
+        body = "Some recipients have Identities"
+        sender = "sender@example.com"
+        recipients = ["recipient1@example.com", "recipient3@example.com"]
+
+        with self.settings(DJEMBE_PLAINTEXT_FALLBACK=True):
+            messages_sent = mail.send_mail(subject, body, sender, recipients, fail_silently=True)
+            self.assertEqual(2, messages_sent)
+
+        with self.settings(DJEMBE_PLAINTEXT_FALLBACK=False):
+            messages_sent = mail.send_mail(subject, body, sender, recipients, fail_silently=True)
+            self.assertEqual(1, messages_sent)
+
+            try:
+                mail.send_mail(subject, body, sender, recipients, fail_silently=False)
+                self.fail('Unencryptable recipients with DJEMBE_PLAINTEXT_FALLBACK=False ' +
+                    'and fail_silently=False should have raised an exception')
+            except UnencryptableRecipients as e:
+                self.assertEqual(e.encrypting_recipients, set(['recipient1@example.com']))
+                self.assertEqual(e.plaintext_recipients, set(['recipient3@example.com']))


### PR DESCRIPTION
add setting to disable plaintext fallback

Djembe traditionally goes through the recipient list looking for
Identities, and sends encrypted emails to those with certificates and
plaintext to the remaining recipients. This change adds a setting,
DJEMBE_PLAINTEXT_FALLBACK, to disable the sending of plaintext emails.
If set to False, it silently drops recipients it can't send encrypted
mail to when fail_silently=True, or raises an exception when
fail_silently=False. Thus, by setting DJEMBE_PLAINTEXT_FALLBACK to
False, you can prevent the sending of plaintext emails, and by sending
with fail_silently=False you can inspect the UnencryptableRecipients to
determine who did and didn't receive encrypted email.